### PR TITLE
fix(AppHeader): add a visible focus ring to the logo link

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -58,7 +58,10 @@ const variants: Record<string, VariantType | ((custom: unknown) => VariantType)>
 <template>
   <UHeader>
     <template #left>
-      <NuxtLink to="/">
+      <NuxtLink
+        to="/"
+        class="focus-visible:outline-3 outline-primary/25 rounded-md p-1 -ms-1"
+      >
         <AppLogo class="h-6 w-auto shrink-0" />
       </NuxtLink>
 


### PR DESCRIPTION
The logo link had no focus style of its own, so tabbing to it fell back to the browser default. Adds the same treatment already shipping in `docs` and `calendar`:

```
focus-visible:outline-3 outline-primary/25 rounded-md p-1 -ms-1
```

`p-1 -ms-1` gives the outline room to breathe without shifting the logo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility Improvements**
  - Added visible keyboard-focus styling to the home-page navigation link while preserving its existing destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->